### PR TITLE
Ability to use only fine-grained token with actions

### DIFF
--- a/.github/workflows/check-duplicates.yml
+++ b/.github/workflows/check-duplicates.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.NIXPKGS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS }}
           ref: ${{ github.head_ref }}
       - run: |
           ./bin/check-duplicates.sh

--- a/.github/workflows/fetch-plugins.yaml
+++ b/.github/workflows/fetch-plugins.yaml
@@ -13,17 +13,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.NIXPKGS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS }}
           ref: ${{ github.head_ref }}
       - name: Install nix
         uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
-            access-tokens = github.com=${{ secrets.NIXPKGS_TOKEN }}
+            access-tokens = github.com=${{ secrets.REPO_ACCESS }}
       - name: Fetch from awesome-neovim
         run: nix run .#update-vim-plugins -- awesome-neovim
         env:
-          GITHUB_TOKEN: ${{ secrets.NIXPKGS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS }}
           SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
       - name: Fetch from m15a
         run: |
@@ -34,7 +34,7 @@ jobs:
           nix run .#update-vim-plugins -- lint
           nix run .#update-vim-plugins
         env:
-          GITHUB_TOKEN: ${{ secrets.NIXPKGS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS }}
           SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
       - name: Check duplicates
         run: |
@@ -45,7 +45,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: fetch-plugins-bot
-          commit_author: Joscha Loos <joscha.loos@rwth-aachen.de>
+          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
           commit_message: 'bot: fetch plugins from various sources'
           file_pattern: manifest.txt pkgs/vim-plugins.nix .previous-update.json
           push_options: '--force'

--- a/.github/workflows/fetch-plugins.yaml
+++ b/.github/workflows/fetch-plugins.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: fetch-plugins-bot
-          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
+          commit_author: Joscha Loos <joscha.loos@rwth-aachen.de>
           commit_message: 'bot: fetch plugins from various sources'
           file_pattern: manifest.txt pkgs/vim-plugins.nix .previous-update.json
           push_options: '--force'

--- a/.github/workflows/pr-check-duplicates.yml
+++ b/.github/workflows/pr-check-duplicates.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.NIXPKGS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS }}
           ref: ${{ github.head_ref }}
       - run: |
           ./bin/check-duplicates.sh "check-only"

--- a/.github/workflows/update-all-plugins.yml
+++ b/.github/workflows/update-all-plugins.yml
@@ -12,21 +12,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.NIXPKGS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS }}
           ref: ${{ github.head_ref }}
       - uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
-            access-tokens = github.com=${{ secrets.NIXPKGS_TOKEN }}
+            access-tokens = github.com=${{ secrets.REPO_ACCESS }}
       - run: nix run .#update-vim-plugins -- update --all
         env:
-          GITHUB_TOKEN: ${{ secrets.NIXPKGS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS }}
           SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: update-plugins-bot
-          commit_user_email: ""
-          commit_author: ""
+          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
           commit_message: 'bot: auto update plugins'
           file_pattern: README.md pkgs/vim-plugins.nix .previous-update.json plugins.md
           push_options: '--force'

--- a/.github/workflows/update-all-plugins.yml
+++ b/.github/workflows/update-all-plugins.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: update-plugins-bot
-          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
+          commit_user_email: ""
+          commit_author: ""
           commit_message: 'bot: auto update plugins'
           file_pattern: README.md pkgs/vim-plugins.nix .previous-update.json plugins.md
           push_options: '--force'

--- a/.github/workflows/update-changes.yaml
+++ b/.github/workflows/update-changes.yaml
@@ -2,7 +2,7 @@ name: Update changes
 
 on:
   pull_request:
-    branches: [ ** ]
+    branches: [ "**" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-changes.yaml
+++ b/.github/workflows/update-changes.yaml
@@ -2,7 +2,7 @@ name: Update changes
 
 on:
   pull_request:
-    branches: [ "**" ]
+    branches: [ main, test, test.pr, test, work ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-changes.yaml
+++ b/.github/workflows/update-changes.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: FetchPluginsBot
-          commit_user_email: 1298403+Blackhole1504@users.noreply.github.com
-          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
+          commit_user_email: joscha.loos@rwth-aachen.de
+          commit_author: Joscha Loos <joscha.loos@rwth-aachen.de>
           commit_message: 'bot: Sync Manifest'
           file_pattern: manifest.txt pkgs/vim-plugins.nix .previous-update.json plugins.md

--- a/.github/workflows/update-changes.yaml
+++ b/.github/workflows/update-changes.yaml
@@ -12,22 +12,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.NIXPKGS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS }}
           ref: ${{ github.head_ref }}
       - uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
-            access-tokens = github.com=${{ secrets.NIXPKGS_TOKEN }}
+            access-tokens = github.com=${{ secrets.REPO_ACCESS }}
       - run: |
           nix run .#update-vim-plugins -- lint
           nix run .#update-vim-plugins
         env:
-          GITHUB_TOKEN: ${{ secrets.NIXPKGS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS }}
           SOURCEHUT_TOKEN: ${{ secrets.SOURCEHUT_TOKEN }}
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: FetchPluginsBot
-          commit_user_email: joscha.loos@rwth-aachen.de
-          commit_author: Joscha Loos <joscha.loos@rwth-aachen.de>
+          commit_user_email: 1298403+Blackhole1504@users.noreply.github.com
+          commit_author: Blackhole1504 <1298403+Blackhole1504@users.noreply.github.com>
           commit_message: 'bot: Sync Manifest'
           file_pattern: manifest.txt pkgs/vim-plugins.nix .previous-update.json plugins.md

--- a/.github/workflows/update-changes.yaml
+++ b/.github/workflows/update-changes.yaml
@@ -2,7 +2,7 @@ name: Update changes
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ ** ]
   workflow_dispatch:
 
 jobs:

--- a/bin/check-duplicates.sh
+++ b/bin/check-duplicates.sh
@@ -3,7 +3,8 @@
 plugins="$(cat ./pkgs/vim-plugins.nix | grep -E "^  [a-zA-Z-]+ =" | sed -E 's/^  ([a-zA-Z-]+) =.*$/\1/' | sort)"
 count=$(echo "$plugins" | uniq -d | wc -l)
 
-known_issues=$(gh issue list --state "open" --label "bot" --json "body" | jq -r ".[].body")
+#known_issues=$(gh issue list --state "open" --label "bot" --json "body" | jq -r ".[].body")
+known_issues=$(gh api -H "Accept: application/vnd.github+json" /repos/NixNeovim/NixNeovimPlugins/issues?labels=bote | jq -r ".[].body")
 
 if [ $count -gt 0 ]
 then
@@ -35,7 +36,16 @@ then
             if ! $found
             then
                 echo "Did not find an issue for $f. Creating a new one ..."
-                gh issue create --title "Detected broken plugin: $f" --label "bot" --body "$f"
+                #gh issue create --title "Detected broken plugin: $f" --label "bot" --body "$f"
+                #gh api --method POST \
+                curl \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $GITHUB_TOKEN"\
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/NixNeovim/NixNeovimPlugins/issues \
+                    -d '{"title":"Detected broken plugin: $f"":"$f","labels":["bot"]}'
+
             else
                 echo "Issue for $f already exists"
             fi

--- a/bin/check-duplicates.sh
+++ b/bin/check-duplicates.sh
@@ -3,7 +3,6 @@
 plugins="$(cat ./pkgs/vim-plugins.nix | grep -E "^  [a-zA-Z-]+ =" | sed -E 's/^  ([a-zA-Z-]+) =.*$/\1/' | sort)"
 count=$(echo "$plugins" | uniq -d | wc -l)
 
-#known_issues=$(gh issue list --state "open" --label "bot" --json "body" | jq -r ".[].body")
 known_issues=$(gh api -H "Accept: application/vnd.github+json" /repos/NixNeovim/NixNeovimPlugins/issues?labels=bote | jq -r ".[].body")
 
 if [ $count -gt 0 ]
@@ -36,8 +35,6 @@ then
             if ! $found
             then
                 echo "Did not find an issue for $f. Creating a new one ..."
-                #gh issue create --title "Detected broken plugin: $f" --label "bot" --body "$f"
-                #gh api --method POST \
                 curl \
                     -X POST \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
By using gh API commands in the bin/check-duplicates.sh file, it is now possible to use only fine-grained tokens.

It is now possible to run the actions with only one fine-grained github token. I chose to keep REPO_ACCESS and removed the NIXPKGS_TOKEN reference in the action files