### PR TITLE
chore: remove deprecated feline

### DIFF
--- a/pkgs/vim-plugins.nix
+++ b/pkgs/vim-plugins.nix
@@ -2991,19 +2991,6 @@
       license = with licenses; [ gpl3Only ];
     };
   };
-  feline-nvim = buildVimPluginFrom2Nix {
-    pname = "feline-nvim"; # Manifest entry: "feline-nvim/feline.nvim"
-    version = "2022-12-22";
-    src = fetchurl {
-      url = "https://github.com/famiu/feline.nvim/archive/d48b6f92c6ccdd6654c956f437be49ea160b5b0c.tar.gz";
-      sha256 = "1jcrw81w753k1qb92xfzk2nlgp88zynpfsvyzl6cc8vc9lgrz80s";
-    };
-    meta = with lib; {
-      description = "A minimal, stylish and customizable statusline for Neovim written in Lua";
-      homepage = "https://github.com/famiu/feline.nvim";
-      license = with licenses; [ gpl3Only ];
-    };
-  };
   falcon = buildVimPluginFrom2Nix {
     pname = "falcon"; # Manifest entry: "fenetikm/falcon"
     version = "2023-03-12";

--- a/plugins.md
+++ b/plugins.md
@@ -234,7 +234,6 @@
 | [f-person/git-blame.nvim](https://github.com/f-person/git-blame.nvim) | 2023-04-06 | `git-blame-nvim` |
 | [f3fora/cmp-spell](https://github.com/f3fora/cmp-spell) | 2022-10-10 | `cmp-spell` |
 | [famiu/bufdelete.nvim](https://github.com/famiu/bufdelete.nvim) | 2023-02-16 | `bufdelete-nvim` |
-| [famiu/feline.nvim](https://github.com/famiu/feline.nvim) | 2022-12-22 | `feline-nvim` |
 | [fenetikm/falcon](https://github.com/fenetikm/falcon) | 2023-03-12 | `falcon` |
 | [filipdutescu/renamer.nvim](https://github.com/filipdutescu/renamer.nvim) | 2022-08-29 | `renamer-nvim` |
 | [folke/lsp-colors.nvim](https://github.com/folke/lsp-colors.nvim) | 2023-02-27 | `lsp-colors-nvim` |


### PR DESCRIPTION
There are duplicated feline plugins here, the old one from `famiu` was deprecated on 16/02/23.


Closes https://github.com/NixNeovim/NixNeovimPlugins/issues/44