### PR TITLE
fix: removed gardenal double entry

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -290,8 +290,6 @@
   repo: nvim-highlight-colors
 - owner: brianaung
   repo: compl.nvim
-- owner: BrunoCiccarino
-  repo: gardenal
 - owner: calind
   repo: selenized.nvim
 - owner: CamdenClark


### PR DESCRIPTION
The `gardenal` plugin is listed twice in `manifest.yaml`:

* first definition on [L272-L274](https://github.com/NixNeovim/NixNeovimPlugins/blob/main/manifest.yaml#L272-L274)
* second definition on [L293-294](https://github.com/NixNeovim/NixNeovimPlugins/blob/main/manifest.yaml#L293-L294)

This breaks evaluations when using NixNeovimPlugins as an overlay. This PR aims to address this by removing the double entry from the `manifest.yaml`. Please see #124 for reference. 